### PR TITLE
fix(docs): small typo on readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const Page = () => (
   </>
 );
 
-export defualt Page
+export default Page
 
 // Output:
 // <head>
@@ -178,7 +178,7 @@ const Page = () => (
     />
   </>
 );
-export defualt Page
+export default Page
 
 // Output:
 // <head>


### PR DESCRIPTION
There's a typo in `README.md` file, simple thing to fix :)